### PR TITLE
Add more nextcloud versions

### DIFF
--- a/content/issues/2023-06-25-nextcloud.md
+++ b/content/issues/2023-06-25-nextcloud.md
@@ -43,6 +43,8 @@ Major version images, to be used for upgrading:
 | `lscr.io/linuxserver/nextcloud:version-24.0.12` | 8.1 |
 | `lscr.io/linuxserver/nextcloud:version-23.0.4`  | 7.4 |
 | `lscr.io/linuxserver/nextcloud:version-22.2.3`  | 7.4 |
+| `lscr.io/linuxserver/nextcloud:version-21.0.3`  | 7.4 |
+| `lscr.io/linuxserver/nextcloud:version-20.0.7`  | 7.4 |
 
 Package locked tags, listed for LSIO team reference:
 


### PR DESCRIPTION
Seeing a lot of support requests where users have versions as far back as 19. We don't have tags on ghcr for anything older than 20. Should be fine for those users to use `lscr.io/linuxserver/nextcloud:version-23.0.4` since it's the same PHP version, but this extra info should help with user confusion.