### PR TITLE
Add custom shields.io endpoint

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -271,6 +271,8 @@ params:
   disrupted: "#cc4400"
   down: "#e60000"
   notice: "#24478f"
+  badge_ok: "#4c1"
+  badge_down: "#e05d44"
 
   # If the status page shows that
   # there are disruptions or outages
@@ -339,8 +341,17 @@ outputs:
     - html
     - json
     - rss
+    - badge
+
+mediaTypes:
+  application/badge:
+    suffixes:
+    - badge
 
 outputFormats:
   svg:
     isPlainText: true
     mediaType: image/svg+xml
+  badge:
+    isPlainText: true
+    mediaType: application/badge

--- a/layouts/affected/list.badge
+++ b/layouts/affected/list.badge
@@ -1,0 +1,25 @@
+{{ $incidents := .Pages }}{{ $active := where $incidents "Params.resolved" "=" false }}{{ $isNotice := where $active "Params.severity" "=" "notice" }}{{ $isDisrupted := where $active "Params.severity" "=" "disrupted" }}{{ $isDown := where $active "Params.severity" "=" "down" -}}
+{{ $status_color := .Site.Params.badge_ok -}}
+{{ $status_text := "OK" -}}
+{{ $status_error := false -}}
+{{ if $isDown -}}
+  {{ $status_text := "Important message" -}}
+  {{ $status_error := true -}}
+  {{ $status_color = .Site.Params.badge_down -}}
+{{ else if $isDisrupted -}}
+  {{ $status_text := "Notice" -}}
+  {{ $status_error := true -}}
+  {{ $status_color = .Site.Params.disrupted -}}
+{{ else if $isNotice -}}
+  {{ $status_text := "Notice" -}}
+  {{ $status_error := true -}}
+  {{ $status_color = .Site.Params.notice -}}
+{{ end -}}
+{
+  "schemaVersion": 1,
+  "label": "Info",
+  "message": "{{ $status_text }}",
+  "color": "{{ $status_color }}",
+  "labelColor": "#555555",
+  "isError": {{ $status_error }}
+}


### PR DESCRIPTION
Adds the affected/<container>/badge.json endpoint to be used with https://shields.io/badges/endpoint-badge, which in turn can be consumed on the readme